### PR TITLE
Various fix

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,5 +5,3 @@ metadata
 group :integration do
   cookbook "docker-compose_test", :path => "./test/cookbooks/docker-compose_test"
 end
-
-cookbook 'docker', github: 'dennybaa/chef-docker'

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Requirements
 
 The cookbook should run on any Linux flavor and it depends on the following cookbooks:
 
- - [docker cookbook (dennybaa/chef-docker)](https://github.com/dennybaa/chef-docker)
- - opscode python cookbook
+ - [docker cookbook (chef-cookbooks/docker)](https://github.com/chef-cookbooks/docker)
+ - python cookbook
 
 Attributes
 ----------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['docker-compose']['config_directory'] = '/etc/compose.d'
-default['docker-compose']['version'] = '1.2.0'
+default['docker-compose']['version'] = '1.5.1'
+default['docker-compose']['include_docker'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.0.1'
 
 depends 'docker'
+depends 'python'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
-include_recipe 'docker'
+include_recipe 'docker' if node['docker-compose']['include_docker']
+include_recipe 'python::default'
 
 directory 'compose.d' do
   path  node['docker-compose']['config_directory']
@@ -21,5 +22,5 @@ bash "Install docker-compose" do
   curl -L https://github.com/docker/compose/releases/download/#{node['docker-compose']['version']}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
 EOH
-  not_if "docker-compose --version | grep -w 'docker-compose #{node['docker-compose']['version']}'"
+  not_if "docker-compose --version | grep -w 'docker-compose version: #{node['docker-compose']['version']}'"
 end


### PR DESCRIPTION
Remove docker cookbook from dennybaa, use supermarket docker cookbook
Use 1.5.1
Don not include docker by default.
Add python cookbook dependency
Fix docker compose version check (not_if)
