### PR TITLE
Prevent "Text file busy" on docker-compsoe upgrade

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,8 @@ package 'curl'
 
 bash "Install docker-compose" do
   code <<-EOH
-  curl -L #{node['docker-compose']['base_url']}/#{node['docker-compose']['version']}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+  curl -L #{node['docker-compose']['base_url']}/#{node['docker-compose']['version']}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose-#{node['docker-compose']['version']}
+  mv /usr/local/bin/docker-compose-#{node['docker-compose']['version']} /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
 EOH
   not_if "docker-compose --version | grep -w 'docker-compose version: #{node['docker-compose']['version']}'"


### PR DESCRIPTION
When I try to upgrade docker-compose from 1.5.1 to 1.7.1, I got a " Text file busy".
We need to copy new docker-compose to a temp file after move it to final name.

```
Recipe: docker-compose::default
  * directory[compose.d] action create (up to date)
  * apt_package[curl] action install (up to date)
  * bash[Install docker-compose] action run
    [execute] /tmp/chef-script20160615-28852-qsrgia: line 1: /usr/local/bin/docker-compose: Text file busy
    - execute "bash"  "/tmp/chef-script20160615-28852-qsrgia"
```
